### PR TITLE
feat: run the hook only if CircleCI config file is changed

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,3 +3,5 @@
   description: This hook validate CircleCI config 
   entry: circleci_validate.sh
   language: script
+  files: .circleci/config.yml
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ```bash
 $ cat .pre-commit-config.yaml
 - repo: https://github.com/zahorniak/pre-commit-circleci.git
-  rev: v0.2 # Ensure this is the latest tag, comparing to the Releases tab
+  rev: v0.3 # Ensure this is the latest tag, comparing to the Releases tab
   hooks:
     - id: circleci_validate
 ```


### PR DESCRIPTION
As of now, the hook is run every time `git commit` is attempted. And validating CircleCI config takes quite a bit of time as compared to other pre-commit linters out there.

And as we are targeting one specific file only, we should only run the hook if that particular file is staged and is going to be committed. And skip running it otherwise.

```bash
$ git status
On branch feat/change-ci-config
Your branch is up to date with 'origin/feat/change-ci-config'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   .circleci/config.yml

$ git commit
Validate CircleCI config.................................................Passed
```
```bash
$ git status
On branch feat/change-something-else
Your branch is up to date with 'origin/feat/change-something-else'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   src/main.py

$ git commit
Validate CircleCI config.............................(no files to check)Skipped
```

P.S.: `pre-commit run --all-files` will still run all the hooks.
