### PR TITLE
Adds ability to pass arguments to circleci config validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ $ cat .pre-commit-config.yaml
     - id: circleci_validate
 ```
 
+If you wish to pass additional args to circleci_validate, you can specify
+them in the config. See `circleci config validate --help` for accepted args.
+
+For example, to set an org-slug:
+```bash
+$ cat .pre-commit-config.yaml
+- repo: https://github.com/zahorniak/pre-commit-circleci.git
+  rev: v0.3 # Ensure this is the latest tag, comparing to the Releases tab
+  hooks:
+    - id: circleci_validate
+      args:
+        - --org-slug my/organization
+```
+
 ## 3. Install hook
 ```bash
 $ pre-commit install

--- a/circleci_validate.sh
+++ b/circleci_validate.sh
@@ -7,7 +7,7 @@ then
     exit 1
 fi
 
-if ! eMSG=$(circleci config validate -c .circleci/config.yml); then
+if ! eMSG=$(circleci config validate $@ -c .circleci/config.yml); then
 	echo "CircleCI Configuration Failed Validation."
 	echo $eMSG
 	exit 1


### PR DESCRIPTION
Passes any args provided by the pre-commit config into the circleci config validate command. This will also fix the issue described in #4 by using a config such as:

```
- repo: git@github.com:zahorniak/pre-commit-circleci.git
    rev: "v0.3"
    hooks:
      - id: circleci_validate
        args:
          - --org-slug <org>
```
