### PR TITLE
feat: Add support for multiple config files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: circleci_validate
   name: Validate CircleCI config
-  description: This hook validate CircleCI config
+  description: This hook validates CircleCI config
   entry: circleci_validate.sh
   language: script
   files: .circleci/.*.yml

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: circleci_validate
   name: Validate CircleCI config
-  description: This hook validate CircleCI config 
+  description: This hook validate CircleCI config
   entry: circleci_validate.sh
   language: script
-  files: .circleci/config.yml
+  files: .circleci/.*.yml
   pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ $ cat .pre-commit-config.yaml
 
 If you wish to pass additional args to circleci_validate, you can specify
 them in the config. See `circleci config validate --help` for accepted args.
+You must use the form `--arg=value`, not `--arg value`.
 
 For example, to set an org-slug:
 ```bash
@@ -23,7 +24,7 @@ $ cat .pre-commit-config.yaml
   hooks:
     - id: circleci_validate
       args:
-        - --org-slug my/organization
+        - --org-slug=my/organization
 ```
 
 Or specify a custom config file:
@@ -34,7 +35,7 @@ $ cat .pre-commit-config.yaml
   hooks:
     - id: circleci_validate
       args:
-        - -c .circleci/continue_config.yml
+        - .circleci/continue_config.yml
 ```
 
 ## 3. Install hook

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ $ cat .pre-commit-config.yaml
         - --org-slug my/organization
 ```
 
+Or specify a custom config file:
+```bash
+$ cat .pre-commit-config.yaml
+- repo: https://github.com/zahorniak/pre-commit-circleci.git
+  rev: v0.5 # Ensure this is the latest tag, comparing to the Releases tab
+  hooks:
+    - id: circleci_validate
+      args:
+        - -c .circleci/continue_config.yml
+```
+
 ## 3. Install hook
 ```bash
 $ pre-commit install

--- a/circleci_validate.sh
+++ b/circleci_validate.sh
@@ -12,7 +12,7 @@ then
     exit 1
 fi
 
-if ! eMSG=$(circleci config validate "$@" -c .circleci/config.yml); then
+if ! eMSG=$(circleci config validate "$@"); then
     echo "CircleCI Configuration Failed Validation."
     echo "${eMSG}"
     exit 1


### PR DESCRIPTION
It was a lot simpler than I thought! This still only validates one file though.

- remove hard coded config file location
- trigger on any `.yml` file in `.circleci/`
- update readme for details on specifying config files

This is possible because by default, `circleci config validate` looks for a config file in `.circleci/config.yml`.