### PR TITLE
feat: Add circleci config process hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 25.1.0
     hooks:
       - id: black
         name: Python black

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,3 +5,10 @@
   language: python
   files: .circleci/.*.yml
   pass_filenames: false
+- id: circleci_process
+  name: Process CircleCI configuration
+  description: This hook process CircleCI configuration
+  entry: circleci-process
+  language: python
+  files: .circleci/.*.yml
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Overview
+
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/zahorniak/pre-commit-circleci?label=latest%20release)](https://github.com/zahorniak/pre-commit-circleci/releases/)
 [![GitHub Release Date - Published_At](https://img.shields.io/github/release-date/zahorniak/pre-commit-circleci)](https://github.com/zahorniak/pre-commit-circleci/releases/)
 
@@ -6,11 +7,16 @@
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/zahorniak/pre-commit-circleci)](https://github.com/zahorniak/pre-commit-circleci/pulls)
 
 # Usage
-## 1. Install dependencies
-* [`pre-commit`](https://pre-commit.com/#install)
-* [`circleci-cli`](https://circleci.com/docs/2.0/local-cli/#installation)
 
-## 2. Create config file ***.pre-commit-config.yaml*** with content:
+## 1. Install dependencies
+
+- [`pre-commit`](https://pre-commit.com/#install)
+- [`circleci-cli`](https://circleci.com/docs/2.0/local-cli/#installation)
+
+## 2. Create config file _.pre-commit-config.yaml_ with content:
+
+- For CircleCI config validation :
+
 ```bash
 $ cat .pre-commit-config.yaml
 - repo: https://github.com/zahorniak/pre-commit-circleci.git
@@ -19,11 +25,23 @@ $ cat .pre-commit-config.yaml
     - id: circleci_validate
 ```
 
-If you wish to pass additional args to circleci_validate, you can specify
-them in the config. See `circleci config validate --help` for accepted args.
-You must use the form `--arg=value`, not `--arg value`.
+- For CircleCI config processing test :
+
+```bash
+$ cat .pre-commit-config.yaml
+- repo: https://github.com/zahorniak/pre-commit-circleci.git
+  rev: v1.1.0 # Ensure this is the latest tag, comparing to the Releases tab
+  hooks:
+    - id: circleci_process
+```
+
+If you wish to pass additional args to circleci_validate or circleci_process,
+you can specify them in the config. See `circleci config validate --help` or
+`circleci config process --help` for accepted args. You must use the form
+`--arg=value`, not `--arg value`.
 
 For example, to set an org-slug:
+
 ```bash
 $ cat .pre-commit-config.yaml
 - repo: https://github.com/zahorniak/pre-commit-circleci.git
@@ -35,39 +53,61 @@ $ cat .pre-commit-config.yaml
 ```
 
 Or specify a custom config file:
+
 ```bash
 $ cat .pre-commit-config.yaml
 - repo: https://github.com/zahorniak/pre-commit-circleci.git
-  rev: v1.1.0 # Ensure this is the latest tag, comparing to the Releases tab
+  rev: v1.1.0
   hooks:
     - id: circleci_validate
       args:
         - .circleci/continue_config.yml
 ```
 
+The CircleCI process hook allow passing multiple configuration files.
+
+For example :
+
+```bash
+$ cat .pre-commit-config.yaml
+- repo: https://github.com/zahorniak/pre-commit-circleci.git
+  rev: v1.1.0
+  hooks:
+    - id: circleci_validate_process
+      args:
+        - '--pipeline-parameters={"foo": "bar"}'
+        - .circleci/config-1.yml
+        - .circleci/config-2.yml
+```
+
 ## 3. Install hook
+
 ```bash
 $ pre-commit install
 pre-commit installed at .git/hooks/pre-commit
 ```
 
 ## 4. Commit code
+
 ```bash
 $ git commit -m "add circleci hook"
 Validate CircleCI config.................................................Passed
+Process CircleCI configuration...........................................Passed
 [branchname 1111111] add circleci hook
  1 file changed, 5 insertions(+), 1 deletion(-)
- ```
+```
 
 ## How hook works
-|   Hook    |   Description    |
-|  ---  |  ---  |
-|   `circleci_validate`    |   Validates CircleCI configuration using command `circleci config validate`    |
 
-
+| Hook                | Description                                                                  |
+| ------------------- | ---------------------------------------------------------------------------- |
+| `circleci_validate` | Validates CircleCI configuration using command `circleci config validate`    |
+| `circleci_process`  | Process the CircleCI configuration(s) using command`circleci config process` |
 
 ### Run hook manually
+
 ```bash
 $ pre-commit run -a
 Validate CircleCI config.................................................Passed
+Process CircleCI configuration...........................................Passed
 ```

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ cat .pre-commit-config.yaml
 - repo: https://github.com/zahorniak/pre-commit-circleci.git
   rev: v1.1.0
   hooks:
-    - id: circleci_validate_process
+    - id: circleci_process
       args:
         - '--pipeline-parameters={"foo": "bar"}'
         - .circleci/config-1.yml

--- a/circleci_process.py
+++ b/circleci_process.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+circleci_validate_process.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A *pre-commit* hook that runs `circleci config process` on one or more
+CircleCI configuration files.
+
+Exit code:
+  * 0  - all configs processed successfully
+  * 1+ - at least one config failed
+"""
+
+from __future__ import annotations
+
+import os
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_process(
+    config_path: Path,
+    org_slug: str | None,
+    org_id: str | None,
+    pipeline_params: str | None,
+    verbose: bool,
+) -> int:
+    """Run `circleci config process` and return its exit code."""
+    cmd: list[str] = ["circleci", "config", "process", str(config_path)]
+
+    if org_slug:
+        cmd.append(f"--org-slug={org_slug}")
+    if org_id:
+        cmd.append(f"--org-id={org_id}")
+    if pipeline_params:
+        cmd.append(f"--pipeline-parameters={pipeline_params}")
+    if verbose:
+        cmd.append("--verbose")
+
+    completed = subprocess.run(cmd, text=True, capture_output=True, check=False)
+    if completed.returncode == 0:
+        # Hide verbose CircleCI output on success
+        print(f"✅  CircleCI configuration passed processing: {config_path}")
+    else:
+        # Re-emit CircleCI output so the user can see the problem
+        sys.stderr.write(completed.stdout + completed.stderr)
+    return completed.returncode
+
+
+def parse_args() -> argparse.Namespace:  # noqa: D401
+    """Return parsed CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run `circleci config process` against the given file(s) inside pre-commit."
+        ),
+    )
+    parser.add_argument(
+        "--org-slug",
+        help="organization slug (e.g. github/example-org) for private orbs",
+    )
+    parser.add_argument(
+        "--org-id",
+        help="organization ID for private orbs",
+    )
+    parser.add_argument(
+        "--pipeline-parameters",
+        help=(
+            "YAML/JSON string or file path with pipeline parameters "
+            '(e.g. \'{"foo": "bar"}\' or params.yml)'
+        ),
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="pass --verbose through to the CircleCI CLI "
+        "(for failing operations in that implementation)",
+    )
+    parser.add_argument(
+        "filenames",
+        nargs="+",
+        help="config files to check",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Entry-point for the pre-commit hook."""
+    args = parse_args()
+
+    # Check if running in CircleCI environment
+    if os.getenv("CIRCLECI"):
+        print("Circleci environment detected, skipping validation.")
+        sys.exit(0)
+
+    exit_code = 0
+    for file_name in args.filenames:
+        path = Path(file_name)
+        if not path.exists():
+            print(f"⚠️  Skipping missing file: {path}", file=sys.stderr)
+            continue
+
+        ret = run_process(
+            config_path=path,
+            org_slug=args.org_slug,
+            org_id=args.org_id,
+            pipeline_params=args.pipeline_parameters,
+            verbose=args.verbose,
+        )
+        exit_code = max(exit_code, ret)
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/circleci_process.py
+++ b/circleci_process.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-circleci_validate_process.py
+circleci_process.py
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A *pre-commit* hook that runs `circleci config process` on one or more

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,11 @@ setup(
     name="pre_commit_circleci",
     version="0.1.0",
     packages=find_packages(),
-    py_modules=["circleci_validate"],
+    py_modules=["circleci_validate", "circleci_process"],
     entry_points={
         "console_scripts": [
             "circleci-validate=circleci_validate:main",
+            "circleci-process=circleci_process:main",
         ],
     },
 )


### PR DESCRIPTION
Add a circleci_config_process pre-commit hook that runs
circleci config process, complementing the existing `circleci_config_validate` hook.

🤔 Why ?
- circleci config validate only checks that a single YAML file is syntactically correct. It does not expand pipelines, resolve orbs, or evaluate pipeline parameters.
- circleci config process does that full expansion, so it catches errors (missing parameters, private-orb auth, etc.) that validate will miss.
- Providing both hooks lets users choose:
  - Fast syntax check (validate)...
  - ... Or full compilation check (process)

I updated the README.md file, hope all is good 🤞 